### PR TITLE
Add go.open-pulse.dev to GOPRIVATE

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Prepare Go for private repos
         run: |
-          go env -w GOPRIVATE=go.appscode.dev/*,github.com/appscode/*,go.bytebuilders.dev/*,go.opscenter.dev/*
+          go env -w GOPRIVATE=go.appscode.dev/*,github.com/appscode/*,go.bytebuilders.dev/*,go.opscenter.dev/*,go.open-pulse.dev/*
 
       - name: Verify PR is from same repo (not a fork)
         env:


### PR DESCRIPTION
## Problem

The Release workflow ([run 29203003818](https://github.com/appscode-cloud/CHANGELOG/actions/runs/29203003818/job/86677442970)) failed while resolving the private vanity module `go.open-pulse.dev/tenant-operator` (backed by the private repo `github.com/opnpulse/tenant-operator`):

```
reading https://sum.golang.org/lookup/go.open-pulse.dev/tenant-operator@...: 404 Not Found
not found: ... git ls-remote https://github.com/opnpulse/tenant-operator: exit status 128:
  fatal: could not read Username for 'https://github.com': terminal prompts disabled
```

Because `go.open-pulse.dev` was not in `GOPRIVATE`, Go tried to verify the module against `sum.golang.org` (404) and route it through the public proxy instead of fetching it directly via git.

## Fix

Add `go.open-pulse.dev/*` to `GOPRIVATE` in the "Prepare Go for private repos" step, matching the other private domains. This bypasses the checksum DB and public proxy, so the existing `insteadOf` token auth (which already covers all of `github.com`) is used to fetch the private repo.